### PR TITLE
Make the coordMap pointer in Compute2DCoordParameters const

### DIFF
--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -522,7 +522,7 @@ unsigned int copyCoordinate(RDKit::ROMol &mol, std::list<EmbeddedFrag> &efrags,
 }
 
 unsigned int compute2DCoords(RDKit::ROMol &mol,
-                             RDGeom::INT_POINT2D_MAP *coordMap,
+                             const RDGeom::INT_POINT2D_MAP *coordMap,
                              bool canonOrient, bool clearConfs,
                              unsigned int nFlipsPerSample,
                              unsigned int nSamples, int sampleSeed,

--- a/Code/GraphMol/Depictor/RDDepictor.h
+++ b/Code/GraphMol/Depictor/RDDepictor.h
@@ -40,7 +40,7 @@ class RDKIT_DEPICTOR_EXPORT DepictException : public std::exception {
 };
 
 struct RDKIT_DEPICTOR_EXPORT Compute2DCoordParameters {
-  RDGeom::INT_POINT2D_MAP *coordMap =
+  const RDGeom::INT_POINT2D_MAP *coordMap =
       nullptr;  //!< a map of int to Point2D, between atom IDs and their
                 //!< locations.  This is the container the user needs to
                 //!< fill if he/she wants to specify coordinates for a portion
@@ -117,7 +117,7 @@ RDKIT_DEPICTOR_EXPORT unsigned int compute2DCoords(
 
 */
 RDKIT_DEPICTOR_EXPORT unsigned int compute2DCoords(
-    RDKit::ROMol &mol, RDGeom::INT_POINT2D_MAP *coordMap = nullptr,
+    RDKit::ROMol &mol, const RDGeom::INT_POINT2D_MAP *coordMap = nullptr,
     bool canonOrient = false, bool clearConfs = true,
     unsigned int nFlipsPerSample = 0, unsigned int nSamples = 0,
     int sampleSeed = 0, bool permuteDeg4Nodes = false, bool forceRDKit = false,


### PR DESCRIPTION
I don't see any particular reason why it shouldn't be const, so we might as well set it that way.

This also allows the swig wrappers to build.